### PR TITLE
Use url encoded value for site names

### DIFF
--- a/gd-geostreaming/CHANGELOG.md
+++ b/gd-geostreaming/CHANGELOG.md
@@ -9,3 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Sensor detail view
   [GEOD-1341](https://opensource.ncsa.illinois.edu/jira/browse/GEOD-1341)
+
+### Changed
+- Use encoded variable for sensor names in the url
+  [GEOD-1347](https://opensource.ncsa.illinois.edu/jira/browse/GEOD-1347)

--- a/gd-geostreaming/src/containers/Sensor/Detail/index.jsx
+++ b/gd-geostreaming/src/containers/Sensor/Detail/index.jsx
@@ -506,7 +506,8 @@ class SensorDetail extends React.Component<Props, State> {
 }
 
 const mapStateToProps = (state, props) => {
-    const sensor = state.__new_sensors.sensors.find(({ name }) => name === props.match.params.name);
+    const sensorName = decodeURIComponent(props.match.params.name);
+    const sensor = state.__new_sensors.sensors.find(({ name }) => name === sensorName);
     return {
         geostreamingEndpoint: state.config.geostreamingEndpoint,
         sourceConfig: sensor && state.config.source[sensor.properties.type.id],

--- a/gd-gltg__old/app/utils/mapPopup.js
+++ b/gd-gltg__old/app/utils/mapPopup.js
@@ -101,7 +101,7 @@ export function popupParameters(feature: ol.Feature, styles: Object) {
             '<i class="material-icons ' + styles.params_icon + '">warning </i>' + '</td>' +
             '<td width="70%">' + 'There are too many parameters to display here. </td></tr>' +
             '<tr><td width="30%" align="right"> </td>' + '<td width="70%"> ' +
-            '<a href="' + detail_link + sensorInfo.name + '/All/" >View Data</a> ' +
+            '<a href="' + detail_link + encodeURIComponent(sensorInfo.name) + '/All/" >View Data</a> ' +
             'to see a full list of parameters for this site.' + ' </td></tr>';
     }
 
@@ -112,7 +112,7 @@ export function popupParameters(feature: ol.Feature, styles: Object) {
 
     let bodyText = '<div class=' + styles.paramsborder + '>' + params + '</div>';
 
-    bodyText += '<a href="' + detail_link + sensorInfo.name + '/All/" class=' +
+    bodyText += '<a href="' + detail_link + encodeURIComponent(sensorInfo.name) + '/All/" class=' +
         styles.viewdetail + ' >View Data</a>';
 
     return bodyText;
@@ -172,7 +172,7 @@ export function popupAnalysis(feature: ol.Feature, styles: Object) {
 
     if (paramsLength > 0 && sensorInfo.trends_detail) {
         bodyText += `<a href="/${location.pathname.split('/')[1]}/detail/location/` +
-            sensorInfo.name + '/All/" class=' +
+            encodeURIComponent(sensorInfo.name) + '/All/" class=' +
             styles.viewsitedetail + ' >View Data for the ' + sensorInfo.name + ' Site </a>';
     }
 
@@ -235,7 +235,7 @@ export function popupTrends(feature: ol.Feature, styles: Object) {
 
     if (paramsLength > 0 && sensorInfo.trends_detail) {
         bodyText += `<a href="/${location.pathname.split('/')[1]}/detail/location/` +
-            sensorInfo.name + '/All/" class=' +
+            encodeURIComponent(sensorInfo.name) + '/All/" class=' +
             styles.viewsitedetail + ' >View Data for the ' + sensorInfo.name + ' Site </a>';
     }
 


### PR DESCRIPTION
## Description
Use url-encoded values for site names in the route path

### Issue link:
https://opensource.ncsa.illinois.edu/jira/browse/GEOD-1347

### What is the current behavior?
If a site has a slash in its name, the router cannot resolve its detail view url. An example site is "MDNR-3941/0.0".

### What is the new behavior (if this is a feature change)?

### Screenshots (if applicable)

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [] Immediately
- [x] Within one week
- [ ] When possible

## Types of changes (select all that applies)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] This changeset requires updating dependencies.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
