### PR TITLE
fixed sensor detail bug in glm__old

### DIFF
--- a/gd-glm__old/app/utils/mapPopup.js
+++ b/gd-glm__old/app/utils/mapPopup.js
@@ -235,7 +235,7 @@ export function popupTrends(feature: ol.Feature, styles: Object) {
 
     if (paramsLength > 0 && sensorInfo.trends_detail) {
         bodyText += '<a href="/trendsstations/detail/location/' +
-            sensorInfo.name + '/All/" class=' +
+            sensorInfo.name + '/All?use-season=1" class=' +
             styles.viewsitedetail + ' >View Data for the ' + sensorInfo.name + ' Site </a>';
     }
 


### PR DESCRIPTION
## Description
Fixed sensor detail page not working from trends Stations page.

How to test:
- Start gd-glm.
- Navigate to Trends Stations page and click on any parameter and the select any sensor. 
- Clicking the `View Data` link should redirect you to the sensor detail page for the selected sensor and the visualizations should be visible now. 

### Issue link:


### What is the current behavior?

- Opening sensor details from Trends Stations Page does not show the available visualizations

### Screenshots (if applicable)

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [ ] Within one week
- [x] When possible

## Types of changes (select all that applies)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the CHANGELOG.md.
- [ ] This changeset requires updating dependencies.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
