### PR TITLE
Fix location of sensor popup

### DIFF
--- a/packages/geostreaming/CHANGELOG.md
+++ b/packages/geostreaming/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+
+## Changed
+- Fixed location of sensor popup on the map
+  [Github-59](https://github.com/geostreams/geodashboard/issues/59)
+
 ## 3.8.0 - 2021-07-13
 
 ### Changed

--- a/packages/geostreaming/src/containers/Map/index.jsx
+++ b/packages/geostreaming/src/containers/Map/index.jsx
@@ -225,7 +225,6 @@ const Map = (props: Props) => {
                         map.getView().fit(
                             geometry.getExtent(),
                             {
-                                maxZoom: mapConfig.maxZoom,
                                 callback: () => popupOverlay.setPosition(geometry.getCoordinates())
                             }
                         );
@@ -247,10 +246,6 @@ const Map = (props: Props) => {
                     dataProjection: 'EPSG:4326',
                     featureProjection: 'EPSG:3857'
                 }))
-            });
-
-            vectorSource.on('addfeature', () => {
-                mapRef.current.getView().fit(vectorSource.getExtent(), { duration: 500 });
             });
 
             const { useCluster, clusterDistance } = mapConfig;


### PR DESCRIPTION
## Description
Sensor popups are fit inside the visible area of the map as much as possible and the map zoom level and extent are preserved when popups are opened and closed.

### Issue link:
Resolves #59 

### What is the current behavior?
Part of sensor popup falls outside of the map and map zoom level changes when a popup is opened and closed.

### What is the new behavior (if this is a feature change)?

### Screenshots (if applicable)

## Review Time Estimate
<!---When do you want your code reviewed by?-->
- [ ] Immediately
- [x] Within one week
- [ ] When possible

## Types of changes (select all that applies)
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the CHANGELOG.md.
- [ ] This changeset requires updating dependencies.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
