### PR TITLE
Fixed search page would not show sensor markers on first render.

### DIFF
--- a/packages/geostreaming/CHANGELOG.md
+++ b/packages/geostreaming/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.9.3 - 2022-03-07
+
+### Fixed
+- Search page would not show sensor markers on first render.
+
 ## 3.9.2 - 2022-02-24
 
 ### Fixed

--- a/packages/geostreaming/package.json
+++ b/packages/geostreaming/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geostreams/geostreaming",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "main": "src/index.jsx",
   "author": "NCSA",
   "publishConfig": {
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@date-io/date-fns": "1.3.13",
-    "@geostreams/core": "^3.6.0",
+    "@geostreams/core": "^3.9.2",
     "@material-ui/pickers": "^3.3.10",
     "clsx": "^1.1.1",
     "d3": "~5.16.0",

--- a/packages/geostreaming/src/containers/Search/index.jsx
+++ b/packages/geostreaming/src/containers/Search/index.jsx
@@ -190,7 +190,7 @@ const Search = (props: Props) => {
         }
 
         setFilteredFeatures(updatedFeatures);
-    }, [filters, custom_location]);
+    }, [features, filters, custom_location]);
 
 
 


### PR DESCRIPTION
Version upped to 3.9.3.