### PR TITLE
fix potential flashing bug on map unmount

### DIFF
--- a/packages/core/src/components/ol/Map.jsx
+++ b/packages/core/src/components/ol/Map.jsx
@@ -97,6 +97,8 @@ const Map = (props: Props) => {
                     map.un(event, handler);
                 });
             }
+
+            map.setTarget(undefined)
         };
     }, []);
 


### PR DESCRIPTION
## Description
This PR will fix a potential bug that causes the map to flash when it refreshes or unmounts.

### What is the current behavior?
Currently, because there is just a single instance of the map, the flashing issue doesn't occur. Still, if in the future, a new map component is to be used, the current version of the map will keep flashing due to improper detachment of the unmounting Map component.

### What is the new behavior (if this is a feature change)?
With the new addition of proper detachment of maps at unmount, it will no longer cause other maps to flash.

