### PR TITLE
Layer info feature

### DIFF
--- a/packages/core/src/components/ol/LayersControl.jsx
+++ b/packages/core/src/components/ol/LayersControl.jsx
@@ -26,6 +26,7 @@ import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 import type { Layer as LayerType } from 'ol/layer';
 
 import { entries } from '../../utils/array';
+import InfoDialog from "@geostreams/geostreaming/src/containers/Explore/InfoDialog";
 
 const useStyle = makeStyles((theme) => ({
     button: {
@@ -82,14 +83,16 @@ type Props = {
     el: HTMLElement;
     layers: { [layerName: string]: LayerType };
     exclude: string[];
+    layersInfo: { [groupName: string]: [string,{[layerName:string]:string}]; };
 }
 
 
-const LayersControl = ({ el, layers, exclude }: Props) => {
+const LayersControl = ({ el, layers, exclude, layersInfo }: Props) => {
     const classes = useStyle();
 
     const [infoDialogControl, toggleInfoDialog] = React.useState(false);
     const [showLayers, updateShowLayers] = React.useState(false);
+    const [dialogInfo, setDialogInfo] = React.useState({ label:'',description:'' });
 
     const [openGroups, updateOpenGroups] = React.useState<{ [groupName: string]: boolean; }>({});
 
@@ -97,9 +100,9 @@ const LayersControl = ({ el, layers, exclude }: Props) => {
         [layerName: string]: { isVisible: boolean; opacity: number; }
     }>({});
 
-    const handleInfoDialog = (e) => {
+    const handleLayerGroupInfoDialog = (e, layerName) => {
         e.stopPropagation();
-        // setSourceId(id);
+        setDialogInfo({ label:layerName, description: layersInfo[layerName][0] });
         toggleInfoDialog(true);
     };
 
@@ -202,16 +205,15 @@ const LayersControl = ({ el, layers, exclude }: Props) => {
                 >
                     <ListItemText primary={groupName} />
                     {isOpen ? <Grid><ChevronDownIcon /> </Grid> : <Grid><ChevronRightIcon /></Grid>}
+                    {(groupName in layersInfo) &&
                     <IconButton
                         style={{ alignSelf: 'flex-start', backgroundColor: 'transparent', color: '#213541', left: '1em' }}
-                        onClick={(e) => handleInfoDialog(e)}
+                        onClick={(e) => handleLayerGroupInfoDialog(e,groupName)}
                         edge="right"
                         size="small"
-                        // id={`info-icon-${classes.sourceCheckbox} `}
-                        // color="secondary"
                     >
                         <InfoOutlinedIcon id={`info-icon-${classes.sourceCheckbox} `} />
-                    </IconButton>
+                    </IconButton>}
                 </ListItem>
                 <Collapse in={isOpen} timeout="auto" unmountOnExit>
                     <List component="div" disablePadding>
@@ -285,6 +287,11 @@ const LayersControl = ({ el, layers, exclude }: Props) => {
                     </List>
                 </CardContent>
             </Card>
+            <InfoDialog
+                dialogControl={infoDialogControl}
+                sourceInfo={dialogInfo}
+                toggleDialog={toggleInfoDialog}
+            />
         </>,
         el
     );

--- a/packages/core/src/components/ol/LayersControl.jsx
+++ b/packages/core/src/components/ol/LayersControl.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { makeStyles } from '@material-ui/core';
+import { Grid, makeStyles } from '@material-ui/core';
 import Accordion from '@material-ui/core/Accordion';
 import AccordionDetails from '@material-ui/core/AccordionDetails';
 import AccordionSummary from '@material-ui/core/AccordionSummary';
@@ -21,6 +21,7 @@ import Typography from '@material-ui/core/Typography';
 import ChevronDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import ChevronRightIcon from '@material-ui/icons/KeyboardArrowRight';
 import CloseIcon from '@material-ui/icons/Close';
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 
 import type { Layer as LayerType } from 'ol/layer';
 
@@ -83,9 +84,11 @@ type Props = {
     exclude: string[];
 }
 
+
 const LayersControl = ({ el, layers, exclude }: Props) => {
     const classes = useStyle();
 
+    const [infoDialogControl, toggleInfoDialog] = React.useState(false);
     const [showLayers, updateShowLayers] = React.useState(false);
 
     const [openGroups, updateOpenGroups] = React.useState<{ [groupName: string]: boolean; }>({});
@@ -93,6 +96,12 @@ const LayersControl = ({ el, layers, exclude }: Props) => {
     const [layersVisibility, updateLayersVisibility] = React.useState<{
         [layerName: string]: { isVisible: boolean; opacity: number; }
     }>({});
+
+    const handleInfoDialog = (e) => {
+        e.stopPropagation();
+        // setSourceId(id);
+        toggleInfoDialog(true);
+    };
 
     const renderLayer = (layer: LayerType) => {
         const title = layer.get('title');
@@ -192,7 +201,17 @@ const LayersControl = ({ el, layers, exclude }: Props) => {
                     })}
                 >
                     <ListItemText primary={groupName} />
-                    {isOpen ? <ChevronDownIcon /> : <ChevronRightIcon />}
+                    {isOpen ? <Grid><ChevronDownIcon /> </Grid> : <Grid><ChevronRightIcon /></Grid>}
+                    <IconButton
+                        style={{ alignSelf: 'flex-start', backgroundColor: 'transparent', color: '#213541', left: '1em' }}
+                        onClick={(e) => handleInfoDialog(e)}
+                        edge="right"
+                        size="small"
+                        // id={`info-icon-${classes.sourceCheckbox} `}
+                        // color="secondary"
+                    >
+                        <InfoOutlinedIcon id={`info-icon-${classes.sourceCheckbox} `} />
+                    </IconButton>
                 </ListItem>
                 <Collapse in={isOpen} timeout="auto" unmountOnExit>
                     <List component="div" disablePadding>

--- a/packages/core/src/components/ol/LayersControl.jsx
+++ b/packages/core/src/components/ol/LayersControl.jsx
@@ -23,10 +23,10 @@ import ChevronRightIcon from '@material-ui/icons/KeyboardArrowRight';
 import CloseIcon from '@material-ui/icons/Close';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
 
+import InfoDialog from '@geostreams/geostreaming/src/containers/Explore/InfoDialog';
 import type { Layer as LayerType } from 'ol/layer';
 
 import { entries } from '../../utils/array';
-import InfoDialog from "@geostreams/geostreaming/src/containers/Explore/InfoDialog";
 
 const useStyle = makeStyles((theme) => ({
     button: {
@@ -100,13 +100,20 @@ const LayersControl = ({ el, layers, exclude, layersInfo }: Props) => {
         [layerName: string]: { isVisible: boolean; opacity: number; }
     }>({});
 
-    const handleLayerGroupInfoDialog = (e, layerName) => {
+
+    const handleLayerGroupInfoDialog = (e, layerGroupName) => {
         e.stopPropagation();
-        setDialogInfo({ label:layerName, description: layersInfo[layerName][0] });
+        setDialogInfo({ label:layerGroupName, description: layersInfo[layerGroupName][0] });
         toggleInfoDialog(true);
     };
 
-    const renderLayer = (layer: LayerType) => {
+    const handleLayerInfoDialog = (e, layerGroupName, layerName) => {
+        e.stopPropagation();
+        setDialogInfo({ label:layerName, description: layersInfo[layerGroupName]?.[1][layerName] });
+        toggleInfoDialog(true);
+    };
+
+    const renderLayer = (layer: LayerType, groupName:string) => {
         const title = layer.get('title');
         const { isVisible, opacity } = layersVisibility[title] || {
             isVisible: layer.getVisible(),
@@ -114,7 +121,6 @@ const LayersControl = ({ el, layers, exclude, layersInfo }: Props) => {
         };
 
         const legend = layer.get('legend');
-
         return (
             <React.Fragment key={title}>
                 <ListItem dense>
@@ -140,6 +146,16 @@ const LayersControl = ({ el, layers, exclude, layersInfo }: Props) => {
                             variant: 'body2'
                         }}
                     />
+                    {(groupName in layersInfo) ? (title in layersInfo[groupName]?.[1]) &&
+                        <IconButton
+                            style={{ alignSelf: 'flex-start', backgroundColor: 'transparent', color: '#213541', left: '1em' }}
+                            onClick={(e) => handleLayerInfoDialog(e, groupName, title)}
+                            edge="right"
+                            size="small"
+                        >
+                            <InfoOutlinedIcon id={`info-icon-${classes.sourceCheckbox} `} />
+                        </IconButton> :
+                        null}
                 </ListItem>
                 {legend ?
                     <ListItem dense>
@@ -247,7 +263,7 @@ const LayersControl = ({ el, layers, exclude, layersInfo }: Props) => {
                                 }}
                             />
                         </ListItem>
-                        {groupLayers.map((subLayer) => renderLayer(subLayer))}
+                        {groupLayers.map((subLayer) => renderLayer(subLayer,groupName))}
                     </List>
                 </Collapse>
             </React.Fragment>

--- a/packages/core/src/components/ol/infoDialog.jsx
+++ b/packages/core/src/components/ol/infoDialog.jsx
@@ -1,0 +1,104 @@
+// @flow
+import React from 'react';
+import { makeStyles } from '@material-ui/core';
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Link from '@material-ui/core/Link';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
+import CloseIcon from '@material-ui/icons/Close';
+
+import type { SourceConfig } from '../../utils/flowtype';
+
+/*
+ Displays the dialog box for more information about the sources.
+ Props:
+    sourceInfo: sourcesConfig object with details of the source that needs to shown.
+    dialogControl: Control for whether the dialog is open or not
+    toggleDialog: Function to toggle dialogControl
+*/
+
+const useStyles = makeStyles((theme) => ({
+    closeButton: {
+        position: 'absolute',
+        right: theme.spacing(2),
+        top: theme.spacing(2),
+        color: 'red'
+    },
+    content: {
+        marginBottom: theme.spacing(2)
+    }
+}));
+
+type Props = {
+    sourceInfo: SourceConfig;
+    dialogControl: boolean,
+    toggleDialog: Function
+}
+
+function InfoDialog(props: Props) {
+    const open = props.dialogControl;
+    const sourceInfo = props.sourceInfo || {};
+
+    const classes = useStyles();
+
+    return (
+        <Dialog
+            open={open}
+            onClose={()=> props.toggleDialog(false)}
+            scroll="paper"
+            PaperProps={{
+                square: true
+            }}
+            fullWidth
+            maxWidth="md"
+        >
+            <DialogTitle id="scroll-dialog-title" disableTypography>
+                <Typography variant="h6">{sourceInfo.label}</Typography>
+                <IconButton
+                    className={classes.closeButton}
+                    size="small"
+                    onClick={()=> props.toggleDialog(false)}
+                >
+                    <CloseIcon />
+                </IconButton>
+            </DialogTitle>
+            <DialogContent className={classes.content}>
+                <DialogContentText
+                    id="scroll-dialog-description"
+                    variant="body1"
+                    tabIndex={-1}
+                    dangerouslySetInnerHTML={{
+                        __html: sourceInfo.description
+                    }}
+                />
+                <DialogContentText>
+                    {sourceInfo.qaqc}
+                </DialogContentText>
+                <Link
+                    href={sourceInfo.link}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    variant="subtitle2"
+                    color="primary"
+                >
+                    {sourceInfo.more_info}
+                </Link>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+InfoDialog.defaultProps = {
+    sourceInfo: {
+        label: '',
+        description: '',
+        qaqc: '',
+        more_info: '',
+        link: ''
+    }
+};
+
+export default InfoDialog;

--- a/packages/geostreaming/src/containers/Explore/Sidebar.jsx
+++ b/packages/geostreaming/src/containers/Explore/Sidebar.jsx
@@ -18,10 +18,10 @@ import BaseSidebar from '@geostreams/core/src/components/theme/BaseSidebar';
 import SidebarCategory from '@geostreams/core/src/components/theme/SidebarCategory';
 import { entries } from '@geostreams/core/src/utils/array';
 
+// import InfoDialog from '../../../../core/src/components/ol/infoDialog';
 import { getSourceColor } from '../../utils/sensors';
 
 import type { SensorType, SourceConfig } from '../../utils/flowtype';
-
 import InfoDialog from './InfoDialog';
 
 const useStyles = makeStyles(() => ({

--- a/packages/geostreaming/src/containers/Map/index.jsx
+++ b/packages/geostreaming/src/containers/Map/index.jsx
@@ -475,7 +475,7 @@ const Map = (props: Props) => {
                     el={cacheRef.current.layersControl.element}
                     layers={cacheRef.current.layers}
                     exclude={['basemaps']}
-                    layersInfo = {mapConfig.layersInfo}
+                    layersInfo = { (typeof mapConfig.layersInfo === 'undefined') ? {} : mapConfig.layersInfo}
                 /> :
                 null}
 

--- a/packages/geostreaming/src/containers/Map/index.jsx
+++ b/packages/geostreaming/src/containers/Map/index.jsx
@@ -18,7 +18,8 @@ import { Map as BaseMap } from '@geostreams/core/src/components/ol';
 import Control from '@geostreams/core/src/components/ol/Control';
 import ClusterControl from '@geostreams/core/src/components/ol/ClusterControl';
 import FitViewControl from '@geostreams/core/src/components/ol/FitViewControl';
-import LayersControl from '@geostreams/core/src/components/ol/LayersControl';
+// import LayersControl from '@geostreams/core/src/components/ol/LayersControl';
+import LayersControl from '../../../../core/src/components/ol/LayersControl'
 import { entries } from '@geostreams/core/src/utils/array';
 
 import type { Feature as FeatureType, Map as MapType, MapBrowserEventType } from 'ol';
@@ -474,6 +475,7 @@ const Map = (props: Props) => {
                     el={cacheRef.current.layersControl.element}
                     layers={cacheRef.current.layers}
                     exclude={['basemaps']}
+                    layersInfo = {mapConfig.layersInfo}
                 /> :
                 null}
 

--- a/packages/geostreaming/src/utils/flowtype.js
+++ b/packages/geostreaming/src/utils/flowtype.js
@@ -86,6 +86,9 @@ export type MapConfig = {
     layers: {
         [groupName: string]: MapLayerConfig[];
     };
+    layersInfo: {
+        [groupName: string]: [string,{[layerName:string]:string}];
+    };
 }
 
 export type SourceType = {


### PR DESCRIPTION
The feature to display description of layers and layergroups is added, to enable it needs a dictionary called layersInfo to be passed in the module.exports in config.js, with the following format:-
{ LayerGroupName:[LayerGroupDescription, {LayerName:LayerDescription}...}

During the geostreams meeting, I would like to go over the importing in the files, cos I am unsure about the ones I have done