### PR TITLE
Changing Explore Page

### DIFF
--- a/packages/core/src/components/ol/ClusterControl.jsx
+++ b/packages/core/src/components/ol/ClusterControl.jsx
@@ -17,15 +17,43 @@ type Props = {
     cluster: SourceType;
     defaultDistance: number;
     toggleCallback: ?Function;
+    defaultDisableCluster: boolean;
 }
 
 const ClusterControl = ({
     el,
     cluster,
     defaultDistance,
-    toggleCallback
+    toggleCallback,
+    defaultDisableCluster
 }: Props) => {
     const classes = useStyle();
+
+    // This block helps set the clustering off during the initial render
+    React.useEffect(() => {
+        if (cluster && defaultDisableCluster){
+            cluster.setDistance(0);
+        }
+    }, [cluster]);
+
+    if (defaultDisableCluster){
+        return ReactDOM.createPortal(
+            <FormControlLabel
+                className={classes.label}
+                control={<Checkbox
+                    onChange={(e, isChecked) => {
+                        cluster.setDistance(isChecked ? defaultDistance : 0 );
+                        if (toggleCallback) {
+                            toggleCallback(!isChecked);
+                        }
+                    }}
+                />}
+                label="Enable Map Clustering"
+            />,
+            el
+        );
+    }
+    
     return ReactDOM.createPortal(
         <FormControlLabel
             className={classes.label}
@@ -41,6 +69,7 @@ const ClusterControl = ({
         />,
         el
     );
+    
 };
 
 export default ClusterControl;

--- a/packages/core/src/components/ol/SourcesControl.jsx
+++ b/packages/core/src/components/ol/SourcesControl.jsx
@@ -164,6 +164,7 @@ const SourcesControl = ({
     data,
     sourcesConfig,
     sources,
+    filterSources,
     selectedFeature,
     toggleRegions,
     handlePopupOpen,
@@ -247,6 +248,13 @@ const SourcesControl = ({
         }
     };
 
+    let filteredSources = sources;
+    // Filter sources by id checking if it is in sourcesConfig
+    if (filterSources) {
+        filteredSources = sources.filter((source) => sourcesConfig[source.id]);
+    }
+
+
     return ReactDOM.createPortal(
         <>
             <Button
@@ -297,7 +305,7 @@ const SourcesControl = ({
                                 </Typography>
                             </Grid>
                         </Grid>
-                        {sources.map((source) => {
+                        {filteredSources.map((source) => {
                             const primaryColor = getSourceColor(sourcesConfig[source.id]);
                             const secondaryColor = interpolateRgb(primaryColor, '#FFF')(0.8);
                             if (!data)

--- a/packages/core/src/components/ol/SourcesControl.jsx
+++ b/packages/core/src/components/ol/SourcesControl.jsx
@@ -182,11 +182,15 @@ const SourcesControl = ({
     const [showSensors, updateShowSensors] = React.useState(false);
 
     React.useEffect(() => {
-    // When new data comes in, make all sources visible.
+    // When new data comes in, sets sources to visible unless config sources has parameter defaultVisibility
         if (data) {
             const updatedSourcesVisibility = Object.keys(data).reduce(
                 (regionsVisibility, sourceId) => {
-                    regionsVisibility[sourceId] = true;
+                    if (sourcesConfig[sourceId] && sourcesConfig[sourceId].hasOwnProperty('defaultVisibility') ){
+                        regionsVisibility[sourceId] = sourcesConfig[sourceId].defaultVisibility;
+                    } else {
+                        regionsVisibility[sourceId] = true;
+                    }
                     return regionsVisibility;
                 },
                 {}

--- a/packages/core/src/components/ol/SourcesControl.jsx
+++ b/packages/core/src/components/ol/SourcesControl.jsx
@@ -188,6 +188,10 @@ const SourcesControl = ({
                 (regionsVisibility, sourceId) => {
                     if (sourcesConfig[sourceId] && sourcesConfig[sourceId].hasOwnProperty('defaultVisibility') ){
                         regionsVisibility[sourceId] = sourcesConfig[sourceId].defaultVisibility;
+                        // Set allSources to false if one of the sources is by default off
+                        if (!sourcesConfig[sourceId].defaultVisibility && allSourcesVisibility){
+                            updateAllSourcesVisibility(false)
+                        }
                     } else {
                         regionsVisibility[sourceId] = true;
                     }

--- a/packages/core/src/components/ol/SourcesControl.jsx
+++ b/packages/core/src/components/ol/SourcesControl.jsx
@@ -28,7 +28,7 @@ import InfoDialog from './InfoDialog';
 
 const useStyles = makeStyles((theme) => ({
     button: {
-        width: '10em !important',
+        width: '15em !important',
         height: '2em !important',
         display: 'block',
         margin: '1px',
@@ -253,12 +253,12 @@ const SourcesControl = ({
                 className={`${classes.button} ${showSensors ? 'hidden' : ''}`}
                 onClick={() => updateShowSensors(true)}
             >
-        Explore Sources
+        Monitoring Locations
             </Button>
             <Card className={`${classes.card} ${showSensors ? '' : 'hidden'}`} square>
                 <CardContent className={classes.cardHeader}>
                     <Typography gutterBottom variant="h6">
-            Explore Sources
+            Monitoring Locations
                     </Typography>
                     <IconButton
                         className={classes.closeButton}

--- a/packages/core/src/components/ol/SourcesControl.jsx
+++ b/packages/core/src/components/ol/SourcesControl.jsx
@@ -399,7 +399,10 @@ const SourcesControl = ({
                                     selectedFeature.idx === sensor.idx ?
                                         primaryColor :
                                         secondaryColor,
-                                                                    border: getStatusStyle(sensor)
+                                                                    border: getStatusStyle(sensor),
+                                                                    width: 'auto',
+                                                                    padding: '6px 6px',
+                                                                    overflow: 'ellipsis'
                                                                 }}
                                                                 size="small"
                                                                 disabled={!sourcesVisibility[source.id]}

--- a/packages/core__old/app/components/ExploreSourcesTab.jsx
+++ b/packages/core__old/app/components/ExploreSourcesTab.jsx
@@ -179,7 +179,7 @@ class ExploreSourcesTab extends Component {
                                     this.clickedSourcesAccordion()
                                 }}
                     >
-                        Explore Sources
+                        Monitoring Locations
                         <Icon className={"material-icons " + exploreStyles.accordionIcon}
                               name={this.state.accordion_icon ? 'expand_more' : 'chevron_right'}
                         />

--- a/packages/geostreaming/src/containers/Explore/Sidebar.jsx
+++ b/packages/geostreaming/src/containers/Explore/Sidebar.jsx
@@ -223,12 +223,12 @@ const Sidebar = ({
         className={`${classes.button} ${showSensors ? "hidden" : ""}`}
         onClick={() => updateShowSensors(true)}
       >
-        Explore Sources
+        Monitoring Locations
       </Button>
       <Card className={`${classes.card} ${showSensors ? "" : "hidden"}`} square>
         <CardContent className={classes.cardHeader}>
           <Typography gutterBottom variant="h6">
-            Explore Sources
+            Monitoring Locations
           </Typography>
           <IconButton
             className={classes.closeButton}

--- a/packages/geostreaming/src/containers/Explore/index.jsx
+++ b/packages/geostreaming/src/containers/Explore/index.jsx
@@ -58,6 +58,7 @@ const Explore = (props: Props) => {
         parameters,
         sensors,
         sources,
+        filterSources,
         sourcesConfig,
         displayOnlineStatus
     } = props;
@@ -153,6 +154,7 @@ const Explore = (props: Props) => {
                 zoomToSe={undefined}
                 data={data}
                 sources={sources}
+                filterSources={filterSources}
                 toggleRegions={updateSourcesVisibility}
                 handlePopupOpen={(idx) => handleFeatureToggle(idx, true)}
                 handlePopupClose={() => handleFeatureToggle()}
@@ -170,6 +172,7 @@ const Explore = (props: Props) => {
 const mapStateToProps = (state) => ({
     mapConfig: state.config.map,
     sourcesConfig: state.config.source,
+    filterSources:state.config.filterSources,
     displayOnlineStatus: state.config.sensors.displayOnlineStatus,
     sensors: state.__new_sensors.sensors.sort(
         (sensor1, sensor2) =>

--- a/packages/geostreaming/src/containers/Explore/index.jsx
+++ b/packages/geostreaming/src/containers/Explore/index.jsx
@@ -41,6 +41,8 @@ type Props = {
     fetchSensors: Function;
     fetchParameters: Function;
     displayOnlineStatus: boolean;
+    filterSources:boolean;
+    defaultDisableCluster:boolean;
 }
 
 type Data = {
@@ -59,6 +61,7 @@ const Explore = (props: Props) => {
         sensors,
         sources,
         filterSources,
+        defaultDisableCluster,
         sourcesConfig,
         displayOnlineStatus
     } = props;
@@ -155,6 +158,7 @@ const Explore = (props: Props) => {
                 data={data}
                 sources={sources}
                 filterSources={filterSources}
+                defaultDisableCluster={defaultDisableCluster}
                 toggleRegions={updateSourcesVisibility}
                 handlePopupOpen={(idx) => handleFeatureToggle(idx, true)}
                 handlePopupClose={() => handleFeatureToggle()}
@@ -173,6 +177,7 @@ const mapStateToProps = (state) => ({
     mapConfig: state.config.map,
     sourcesConfig: state.config.source,
     filterSources:state.config.filterSources,
+    defaultDisableCluster:state.config.defaultDisableCluster,
     displayOnlineStatus: state.config.sensors.displayOnlineStatus,
     sensors: state.__new_sensors.sensors.sort(
         (sensor1, sensor2) =>

--- a/packages/geostreaming/src/containers/Map/index.jsx
+++ b/packages/geostreaming/src/containers/Map/index.jsx
@@ -84,6 +84,7 @@ interface Props {
   mapConfig: MapConfig;
   sourcesConfig: { [k: string]: SourceConfig };
   filterSources: boolean;
+  defaultDisableCluster:boolean;
   displayOnlineStatus: boolean;
   parameters: ParameterType[];
   sensors: SensorType[];
@@ -206,6 +207,7 @@ const Map = (props: Props) => {
         data,
         sources,
         filterSources,
+        defaultDisableCluster,
         toggleRegions,
         handlePopupClose,
         handlePopupOpen
@@ -571,6 +573,7 @@ const Map = (props: Props) => {
                             map.getView().setZoom(map.getView().getZoom() + 0.001);
                         }
                     }}
+                    defaultDisableCluster={defaultDisableCluster}
                 />
             ) : null}
             {showExploreSources ? (

--- a/packages/geostreaming/src/containers/Map/index.jsx
+++ b/packages/geostreaming/src/containers/Map/index.jsx
@@ -83,6 +83,7 @@ const useStyles = makeStyles((theme) => ({
 interface Props {
   mapConfig: MapConfig;
   sourcesConfig: { [k: string]: SourceConfig };
+  filterSources: boolean;
   displayOnlineStatus: boolean;
   parameters: ParameterType[];
   sensors: SensorType[];
@@ -204,6 +205,7 @@ const Map = (props: Props) => {
     handleFeatureToggle,
     data,
     sources,
+    filterSources,
     toggleRegions,
     handlePopupClose,
     handlePopupOpen,
@@ -569,6 +571,7 @@ const Map = (props: Props) => {
           handlePopupOpen={handlePopupOpen}
           handlePopupClose={handlePopupClose}
           className={classes.sourcesControl}
+          filterSources={filterSources}
         />
       ) : null}
       {mapConfig.layers && showExploreLayers ? (

--- a/packages/geostreaming/src/containers/Map/index.jsx
+++ b/packages/geostreaming/src/containers/Map/index.jsx
@@ -1,83 +1,83 @@
 // @flow
-import React from "react";
-import { scaleLinear } from "d3";
-import { makeStyles } from "@material-ui/core";
-import GeoJSON from "ol/format/GeoJSON";
-import GroupLayer from "ol/layer/Group";
-import ImageLayer from "ol/layer/Image";
-import TileLayer from "ol/layer/Tile";
-import ClusterSource from "ol/source/Cluster";
-import ImageWMSSource from "ol/source/ImageWMS";
-import XYZ from "ol/source/XYZ";
-import OSM from "ol/source/OSM";
-import VectorSource from "ol/source/Vector";
-import { Circle, Fill, Icon, Stroke, Style, Text } from "ol/style";
-import SelectClusterInteraction from "ol-ext/interaction/SelectCluster";
-import AnimatedClusterLayer from "ol-ext/layer/AnimatedCluster";
-import { Map as BaseMap } from "@geostreams/core/src/components/ol";
-import Control from "@geostreams/core/src/components/ol/Control";
-import ClusterControl from "@geostreams/core/src/components/ol/ClusterControl";
-import FitViewControl from "@geostreams/core/src/components/ol/FitViewControl";
-import LayersControl from "@geostreams/core/src/components/ol/LayersControl";
-import SourcesControl from "@geostreams/core/src/components/ol/SourcesControl";
+import React from 'react';
+import { scaleLinear } from 'd3';
+import { makeStyles } from '@material-ui/core';
+import GeoJSON from 'ol/format/GeoJSON';
+import GroupLayer from 'ol/layer/Group';
+import ImageLayer from 'ol/layer/Image';
+import TileLayer from 'ol/layer/Tile';
+import ClusterSource from 'ol/source/Cluster';
+import ImageWMSSource from 'ol/source/ImageWMS';
+import XYZ from 'ol/source/XYZ';
+import OSM from 'ol/source/OSM';
+import VectorSource from 'ol/source/Vector';
+import { Circle, Fill, Icon, Stroke, Style, Text } from 'ol/style';
+import SelectClusterInteraction from 'ol-ext/interaction/SelectCluster';
+import AnimatedClusterLayer from 'ol-ext/layer/AnimatedCluster';
+import { Map as BaseMap } from '@geostreams/core/src/components/ol';
+import Control from '@geostreams/core/src/components/ol/Control';
+import ClusterControl from '@geostreams/core/src/components/ol/ClusterControl';
+import FitViewControl from '@geostreams/core/src/components/ol/FitViewControl';
+import LayersControl from '@geostreams/core/src/components/ol/LayersControl';
+import SourcesControl from '@geostreams/core/src/components/ol/SourcesControl';
 import { entries } from '@geostreams/core/src/utils/array';
 
 import type {
-  Feature as FeatureType,
-  Map as MapType,
-  MapBrowserEventType,
-} from "ol";
-import type { Layer as LayerType } from "ol/layer";
-import type { MapLayerConfig } from "@geostreams/core/src/utils/flowtype";
+    Feature as FeatureType,
+    Map as MapType,
+    MapBrowserEventType
+} from 'ol';
+import type { Layer as LayerType } from 'ol/layer';
+import type { MapLayerConfig } from '@geostreams/core/src/utils/flowtype';
 
-import { getSensorName, getSourceColor } from "../../utils/sensors";
-import SensorPopup from "../Sensor/Popup";
+import { getSensorName, getSourceColor } from '../../utils/sensors';
+import SensorPopup from '../Sensor/Popup';
 
 import type {
-  MapConfig,
-  ParameterType,
-  SensorType,
-  SourceConfig,
-} from "../../utils/flowtype";
+    MapConfig,
+    ParameterType,
+    SensorType,
+    SourceConfig
+} from '../../utils/flowtype';
 
 const useStyles = makeStyles((theme) => ({
-  content: {
-    height: "100%",
-    flexGrow: 1,
-    position:"relative"
-  },
-  fitViewControl: {
-    bottom: ".5em",
-    left: ".5em",
-  },
-  clusterControl: {
-    display: "flex",
-    justifyContent: "center",
-    width: "max-content",
-    bottom: ".5em",
-    right: 0,
-    left: 0,
-    marginLeft: "auto",
-    marginRight: "auto",
-    padding: 0,
-    background: "transparent",
-    "&:hover": {
-      background: "transparent",
+    content: {
+        height: '100%',
+        flexGrow: 1,
+        position:'relative'
     },
-    "& > label": {
-      padding: "0 10px",
-      color: theme.palette.primary.contrastText,
-      backgroundColor: theme.palette.primary.main,
+    fitViewControl: {
+        bottom: '.5em',
+        left: '.5em'
     },
-  },
-  layersControl: {
-    top: "0.5em",
-    right: "0.5em",
-  },
-  sourcesControl: {
-    top: "0.5em",
-    left: "2.5em",
-  },
+    clusterControl: {
+        'display': 'flex',
+        'justifyContent': 'center',
+        'width': 'max-content',
+        'bottom': '.5em',
+        'right': 0,
+        'left': 0,
+        'marginLeft': 'auto',
+        'marginRight': 'auto',
+        'padding': 0,
+        'background': 'transparent',
+        '&:hover': {
+            background: 'transparent'
+        },
+        '& > label': {
+            padding: '0 10px',
+            color: theme.palette.primary.contrastText,
+            backgroundColor: theme.palette.primary.main
+        }
+    },
+    layersControl: {
+        top: '0.5em',
+        right: '0.5em'
+    },
+    sourcesControl: {
+        top: '0.5em',
+        left: '2.5em'
+    }
 }));
 
 interface Props {
@@ -109,129 +109,131 @@ interface Props {
 }
 
 const getMarker = (fill: string, stroke: string) =>
-  encodeURIComponent(
-    `<svg width="15" height="25" xmlns="http://www.w3.org/2000/svg" style="cursor: pointer">
+    encodeURIComponent(
+        `<svg width="15" height="25" xmlns="http://www.w3.org/2000/svg" style="cursor: pointer">
         <path d="M 1 11 A 7 7.5 0 1 1 14 11 L 7.5 25 z" stroke="${stroke}" stroke-width="1" fill="white" />
         <ellipse cx="7.5" cy="8.5" rx="4.5" ry="5.5" fill="${fill}" />
     </svg>`
-  );
+    );
 
 const prepareLayers = (
-  mapTileURL: string,
-  geoserverUrl: string,
-  layersConfig: { [group: string]: MapLayerConfig[] } = {},
-  showExploreLayers: boolean
+    mapTileURL: string,
+    geoserverUrl: string,
+    layersConfig: { [group: string]: MapLayerConfig[] } = {},
+    showExploreLayers: boolean
 ): { [layerName: string]: LayerType } => {
-  let source = new OSM();
-  if (mapTileURL)
-    source = new XYZ({
-      url: mapTileURL,
-    });
-
-  const layers = {
-    basemaps: new GroupLayer({
-      title: "Base Maps",
-      layers: [
-        new TileLayer({
-          type: "base",
-          title: "OSM",
-          source,
-        }),
-      ],
-    }),
-  };
-  if (showExploreLayers)
-    entries(layersConfig).forEach(([group, groupLayersConfig]) => {
-      const groupLayers = [];
-      groupLayersConfig.forEach(
-        ({
-          title,
-          id,
-          type,
-          initialOpacity,
-          initialVisibility,
-          legend,
-        }: MapLayerConfig) => {
-          let layer;
-          if (type === "wms") {
-            layer = new ImageLayer({
-              source: new ImageWMSSource({
-                url: `${geoserverUrl}/wms`,
-                params: { LAYERS: id },
-                ratio: 1,
-                serverType: "geoserver",
-              }),
-              opacity: initialOpacity || 0.8,
-              visible: initialVisibility || false,
-            });
-            layer.set("title", title);
-            if (legend) {
-              layer.set("legend", `${geoserverUrl}/${legend}`);
-            }
-          }
-          if (layer) {
-            if (group) {
-              groupLayers.push(layer);
-            } else {
-              layers[title] = layer;
-            }
-          }
-        }
-      );
-      if (group) {
-        layers[group] = new GroupLayer({
-          title: group,
-          layers: groupLayers,
+    let source = new OSM();
+    if (mapTileURL)
+        source = new XYZ({
+            url: mapTileURL
         });
-      }
-    });
 
-  return layers;
+    const layers = {
+        basemaps: new GroupLayer({
+            title: 'Base Maps',
+            layers: [
+                new TileLayer({
+                    type: 'base',
+                    title: 'OSM',
+                    source
+                })
+            ]
+        })
+    };
+    if (showExploreLayers)
+        entries(layersConfig).forEach(([group, groupLayersConfig]) => {
+            const groupLayers = [];
+            groupLayersConfig.forEach(
+                ({
+                    title,
+                    id,
+                    type,
+                    initialOpacity,
+                    initialVisibility,
+                    legend
+                }: MapLayerConfig) => {
+                    let layer;
+                    if (type === 'wms') {
+                        layer = new ImageLayer({
+                            source: new ImageWMSSource({
+                                url: `${geoserverUrl}/wms`,
+                                params: { LAYERS: id },
+                                ratio: 1,
+                                serverType: 'geoserver'
+                            }),
+                            opacity: initialOpacity || 0.8,
+                            visible: initialVisibility || false
+                        });
+                        layer.set('title', title);
+                        if (legend) {
+                            layer.set('legend', `${geoserverUrl}/${legend}`);
+                        }
+                    }
+                    if (layer) {
+                        if (group) {
+                            groupLayers.push(layer);
+                        } else {
+                            layers[title] = layer;
+                        }
+                    }
+                }
+            );
+            if (group) {
+                layers[group] = new GroupLayer({
+                    title: group,
+                    layers: groupLayers
+                });
+            }
+        });
+
+    return layers;
 };
 
 const Map = (props: Props) => {
-  const {
-    mapConfig,
-    sourcesConfig,
-    displayOnlineStatus,
-    parameters,
-    sensors,
-    features,
-    selectedFeature,
-    showExploreLayers,
-    showExploreSources,
-    additionalLayer: additionalLayerProp,
-    children,
-    handleFeatureToggle,
-    data,
-    sources,
-    filterSources,
-    toggleRegions,
-    handlePopupClose,
-    handlePopupOpen,
-  } = props;
+    const {
+        mapConfig,
+        sourcesConfig,
+        displayOnlineStatus,
+        parameters,
+        sensors,
+        features,
+        selectedFeature,
+        showExploreLayers,
+        showExploreSources,
+        additionalLayer: additionalLayerProp,
+        children,
+        handleFeatureToggle,
+        data,
+        sources,
+        filterSources,
+        toggleRegions,
+        handlePopupClose,
+        handlePopupOpen
+    } = props;
 
-  const classes = useStyles();
+    const classes = useStyles();
 
-  // Holds an instance of @geostreams/core/ol/Map component
-  const mapRef = React.useRef<MapType>();
+    // Holds an instance of @geostreams/core/ol/Map component
+    const mapRef = React.useRef<MapType>();
 
-  const popupContainerRef = React.useRef<?HTMLDivElement>();
+    const popupContainerRef = React.useRef<?HTMLDivElement>();
 
-  const clusterRef = React.useRef();
+    const clusterRef = React.useRef();
 
-  const [isClusterEnabled, toggleCluster] = React.useState(
-    mapConfig.useCluster
-  );
+    const [isClusterEnabled, toggleCluster] = React.useState(
+        mapConfig.useCluster
+    );
 
-  const [additionalLayer, setAdditionalLayer] =
+    const [additionalLayer, setAdditionalLayer] =
     React.useState(additionalLayerProp);
 
-  // This is used to cache map styles
-  const mapStylesRef = React.useRef<{ [styleName: string]: Style }>({});
+    const [filteredFeatures, setFilteredFeatures] = React.useState(features);
 
-  // Caches the map layers and controls
-  const cacheRef = React.useRef<{
+    // This is used to cache map styles
+    const mapStylesRef = React.useRef<{ [styleName: string]: Style }>({});
+
+    // Caches the map layers and controls
+    const cacheRef = React.useRef<{
     initiated: boolean,
     layers: { [layerName: string]: LayerType },
     layersControl: Control,
@@ -240,376 +242,387 @@ const Map = (props: Props) => {
     clusterControl: Control,
   }>({});
 
-  if (!cacheRef.current.initiated) {
-    cacheRef.current = {
-      initiated: true,
-      layers: prepareLayers(
-        mapConfig.mapTileURL,
-        mapConfig.geoserverUrl,
-        mapConfig.layers,
-        showExploreLayers
-      ),
-      layersControl: new Control({
-        className: classes.layersControl,
-      }),
-      sourcesControl: new Control({
-        className: classes.sourcesControl,
-      }),
-      fitViewControl: new Control({
-        className: classes.fitViewControl,
-      }),
-      clusterControl: new Control({
-        className: classes.clusterControl,
-      }),
-    };
-  }
-
-  React.useEffect(() => {
-    const map = mapRef.current;
-    if (map) {
-      const popupOverlay = map.getOverlayById("popup");
-      if (selectedFeature) {
-        const feature = features.find(
-          (obj) => obj.get("idx") === selectedFeature.idx
-        );
-        if (feature) {
-          const geometry = feature.getGeometry();
-          if (selectedFeature.zoom) {
-            map.getView().fit(geometry.getExtent(), {
-              callback: () =>
-                popupOverlay.setPosition(geometry.getCoordinates()),
-            });
-          } else {
-            popupOverlay.setPosition(geometry.getCoordinates());
-          }
-        }
-      } else {
-        popupOverlay.setPosition();
-      }
+    if (!cacheRef.current.initiated) {
+        cacheRef.current = {
+            initiated: true,
+            layers: prepareLayers(
+                mapConfig.mapTileURL,
+                mapConfig.geoserverUrl,
+                mapConfig.layers,
+                showExploreLayers
+            ),
+            layersControl: new Control({
+                className: classes.layersControl
+            }),
+            sourcesControl: new Control({
+                className: classes.sourcesControl
+            }),
+            fitViewControl: new Control({
+                className: classes.fitViewControl
+            }),
+            clusterControl: new Control({
+                className: classes.clusterControl
+            })
+        };
     }
-  }, [selectedFeature]);
 
-  React.useEffect(() => {
+    // Use useEffect to filter features based on sourcesConfig
+    React.useEffect(() => {
+        if (filterSources){
+            setFilteredFeatures(features.filter(
+                (feature) => sourcesConfig[feature.getProperties().properties.type.id.toLowerCase()]
+            ));
+        }else {
+            setFilteredFeatures(features);
+        }
+    }, [features, sourcesConfig]);
+
+    React.useEffect(() => {
+        const map = mapRef.current;
+        if (map) {
+            const popupOverlay = map.getOverlayById('popup');
+            if (selectedFeature) {
+                const feature = features.find(
+                    (obj) => obj.get('idx') === selectedFeature.idx
+                );
+                if (feature) {
+                    const geometry = feature.getGeometry();
+                    if (selectedFeature.zoom) {
+                        map.getView().fit(geometry.getExtent(), {
+                            callback: () =>
+                                popupOverlay.setPosition(geometry.getCoordinates())
+                        });
+                    } else {
+                        popupOverlay.setPosition(geometry.getCoordinates());
+                    }
+                }
+            } else {
+                popupOverlay.setPosition();
+            }
+        }
+    }, [selectedFeature]);
+
+    React.useEffect(() => {
     // Add cluster resource on mount
-    if (mapRef.current) {
-      const vectorSource = new VectorSource({
-        format: new GeoJSON({
-          dataProjection: "EPSG:4326",
-          featureProjection: "EPSG:3857",
-        }),
-      });
+        if (mapRef.current) {
+            const vectorSource = new VectorSource({
+                format: new GeoJSON({
+                    dataProjection: 'EPSG:4326',
+                    featureProjection: 'EPSG:3857'
+                })
+            });
 
-      const { useCluster, clusterDistance } = mapConfig;
+            const { useCluster, clusterDistance } = mapConfig;
 
-      const clusterSource = new ClusterSource({
-        distance: useCluster ? clusterDistance : 0,
-        source: vectorSource,
-      });
+            const clusterSource = new ClusterSource({
+                distance: useCluster ? clusterDistance : 0,
+                source: vectorSource
+            });
 
-      const getMarkerColor = (feature) => {
-        if (feature.get("features")) {
-          const properties = feature.get("features")[0].get("properties");
-          const fillColor = getSourceColor(
-            sourcesConfig[properties.type.id.toLowerCase()]
-          );
-          let strokeColor = "black";
-          if (displayOnlineStatus) {
-            if (properties.online_status === "online") {
-              strokeColor = "green";
+            const getMarkerColor = (feature) => {
+                if (feature.get('features')) {
+                    const properties = feature.get('features')[0].get('properties');
+                    const fillColor = getSourceColor(
+                        sourcesConfig[properties.type.id.toLowerCase()]
+                    );
+                    let strokeColor = 'black';
+                    if (displayOnlineStatus) {
+                        if (properties.online_status === 'online') {
+                            strokeColor = 'green';
+                        }
+                        if (properties.online_status === 'offline') {
+                            strokeColor = 'red';
+                        }
+                    }
+                    return [fillColor, strokeColor];
+                }
+                return ['pink', 'pink'];
+            };
+
+            const getClusteredStyle = (size) => {
+                const radiusScale = scaleLinear()
+                    .range([10, 20])
+                    .domain([0, 300])
+                    .clamp(true);
+
+                const styleName = `cluster-${size}`;
+
+                const mapStyles = mapStylesRef.current;
+                let style = mapStyles[styleName];
+                if (!style) {
+                    style = new Style({
+                        image: new Circle({
+                            radius: radiusScale(size),
+                            stroke: new Stroke({
+                                color: '#fff'
+                            }),
+                            fill: new Fill({
+                                color: '#3399CC'
+                            })
+                        }),
+                        text: new Text({
+                            text: size.toString(),
+                            fill: new Fill({
+                                color: '#fff'
+                            })
+                        })
+                    });
+                }
+
+                mapStyles[styleName] = style;
+                mapStylesRef.current = mapStyles;
+                return style;
+            };
+
+            const getSelectedStyle = (feature) => {
+                const [fillColor, strokeColor] = getMarkerColor(feature);
+                const styleName = `cluster-${fillColor}-${strokeColor}`;
+                const mapStyles = mapStylesRef.current;
+                let style = mapStyles[styleName];
+                if (!style) {
+                    style = new Style({
+                        image: new Icon({
+                            src: `data:image/svg+xml;utf-8,${getMarker(
+                                fillColor,
+                                strokeColor
+                            )}`
+                        })
+                    });
+                }
+
+                mapStyles[styleName] = style;
+                mapStylesRef.current = mapStyles;
+                return style;
+            };
+
+            const getStyle = (feature) => {
+                // Handled null error when click propagated from non-feature layers
+                if (!feature.getKeys().includes('features')) return null;
+                const size = feature.get('features').length;
+
+                if (size === 1 || !isClusterEnabled) {
+                    return getSelectedStyle(feature);
+                }
+                return getClusteredStyle(size);
+            };
+
+            const clusters = new AnimatedClusterLayer({
+                source: clusterSource,
+                style: getStyle,
+                zIndex: Infinity
+            });
+
+            const selectCluster = new SelectClusterInteraction({
+                pointRadius: 17,
+                animate: true,
+                spiral: true,
+                // Feature style when it springs apart
+                featureStyle: (feature) => {
+                    const [fillColor, strokeColor] = getMarkerColor(feature);
+                    return new Style({
+                        image: new Icon({
+                            src: `data:image/svg+xml;utf-8,${getMarker(
+                                fillColor,
+                                strokeColor
+                            )}`
+                        }),
+                        // Draw a link between points (or not)
+                        stroke: new Stroke({
+                            color: '#fff',
+                            width: 1
+                        })
+                    });
+                },
+                // Style to draw cluster when selected
+                style: getStyle
+            });
+
+            mapRef.current.addLayer(clusters);
+            mapRef.current.addInteraction(selectCluster);
+            clusterRef.current = clusterSource;
+        }
+    }, []);
+
+    React.useEffect(() => {
+        if (mapRef.current) {
+            if (additionalLayer) {
+                mapRef.current.removeLayer(additionalLayer);
             }
-            if (properties.online_status === "offline") {
-              strokeColor = "red";
+            if (additionalLayerProp) {
+                const layerSource = additionalLayerProp.getSource();
+
+                layerSource.on('addfeature', () => {
+                    if (layerSource.getFeatures().length > 0)
+                        mapRef.current
+                            .getView()
+                            .fit(layerSource.getExtent(), { duration: 500 });
+                });
+                mapRef.current.addLayer(additionalLayerProp);
             }
-          }
-          return [fillColor, strokeColor];
+            setAdditionalLayer(additionalLayerProp);
         }
-        return ["pink", "pink"];
-      };
+    }, [additionalLayerProp]);
 
-      const getClusteredStyle = (size) => {
-        const radiusScale = scaleLinear()
-          .range([10, 20])
-          .domain([0, 300])
-          .clamp(true);
-
-        const styleName = `cluster-${size}`;
-
-        const mapStyles = mapStylesRef.current;
-        let style = mapStyles[styleName];
-        if (!style) {
-          style = new Style({
-            image: new Circle({
-              radius: radiusScale(size),
-              stroke: new Stroke({
-                color: "#fff",
-              }),
-              fill: new Fill({
-                color: "#3399CC",
-              }),
-            }),
-            text: new Text({
-              text: size.toString(),
-              fill: new Fill({
-                color: "#fff",
-              }),
-            }),
-          });
+    React.useEffect(() => {
+        const cluster = clusterRef.current;
+        if (cluster) {
+            const source = cluster.getSource();
+            source.clear();
+            source.addFeatures(filteredFeatures);
+            // if(mapRef)
+            //     mapRef.current.getView().fit(source.getExtent(), { duration: 500 });
         }
+    }, [filteredFeatures]);
 
-        mapStyles[styleName] = style;
-        mapStylesRef.current = mapStyles;
-        return style;
-      };
-
-      const getSelectedStyle = (feature) => {
-        const [fillColor, strokeColor] = getMarkerColor(feature);
-        const styleName = `cluster-${fillColor}-${strokeColor}`;
-        const mapStyles = mapStylesRef.current;
-        let style = mapStyles[styleName];
-        if (!style) {
-          style = new Style({
-            image: new Icon({
-              src: `data:image/svg+xml;utf-8,${getMarker(
-                fillColor,
-                strokeColor
-              )}`,
-            }),
-          });
-        }
-
-        mapStyles[styleName] = style;
-        mapStylesRef.current = mapStyles;
-        return style;
-      };
-
-      const getStyle = (feature) => {
-        // Handled null error when click propagated from non-feature layers
-        if (!feature.getKeys().includes("features")) return null;
-        const size = feature.get("features").length;
-
-        if (size === 1 || !isClusterEnabled) {
-          return getSelectedStyle(feature);
-        }
-        return getClusteredStyle(size);
-      };
-
-      const clusters = new AnimatedClusterLayer({
-        source: clusterSource,
-        style: getStyle,
-        zIndex: Infinity,
-      });
-
-      const selectCluster = new SelectClusterInteraction({
-        pointRadius: 17,
-        animate: true,
-        spiral: true,
-        // Feature style when it springs apart
-        featureStyle: (feature) => {
-          const [fillColor, strokeColor] = getMarkerColor(feature);
-          return new Style({
-            image: new Icon({
-              src: `data:image/svg+xml;utf-8,${getMarker(
-                fillColor,
-                strokeColor
-              )}`,
-            }),
-            // Draw a link between points (or not)
-            stroke: new Stroke({
-              color: "#fff",
-              width: 1,
-            }),
-          });
-        },
-        // Style to draw cluster when selected
-        style: getStyle,
-      });
-
-      mapRef.current.addLayer(clusters);
-      mapRef.current.addInteraction(selectCluster);
-      clusterRef.current = clusterSource;
-    }
-  }, []);
-
-  React.useEffect(() => {
-    if (mapRef.current) {
-      if (additionalLayer) {
-        mapRef.current.removeLayer(additionalLayer);
-      }
-      if (additionalLayerProp) {
-        const layerSource = additionalLayerProp.getSource();
-
-        layerSource.on("addfeature", () => {
-          if (layerSource.getFeatures().length > 0)
-            mapRef.current
-              .getView()
-              .fit(layerSource.getExtent(), { duration: 500 });
-        });
-        mapRef.current.addLayer(additionalLayerProp);
-      }
-      setAdditionalLayer(additionalLayerProp);
-    }
-  }, [additionalLayerProp]);
-
-  React.useEffect(() => {
-    const cluster = clusterRef.current;
-    if (cluster) {
-      const source = cluster.getSource();
-      source.clear();
-      source.addFeatures(features);
-      // if(mapRef)
-      //     mapRef.current.getView().fit(source.getExtent(), { duration: 500 });
-    }
-  }, [features]);
-
-  const handleMapClick = (event: MapBrowserEventType) => {
-    if (mapRef.current) {
-      const featuresAtPixel = mapRef.current.forEachFeatureAtPixel(
-        event.pixel,
-        (featureChange) => featureChange
-      );
-      if (
-        featuresAtPixel &&
+    const handleMapClick = (event: MapBrowserEventType) => {
+        if (mapRef.current) {
+            const featuresAtPixel = mapRef.current.forEachFeatureAtPixel(
+                event.pixel,
+                (featureChange) => featureChange
+            );
+            if (
+                featuresAtPixel &&
         featuresAtPixel.attributes &&
-        featuresAtPixel.attributes.type === "single"
-      ) {
-        // Case when a feature is expanded
-      } else if (
-        featuresAtPixel &&
-        featuresAtPixel.get("features") &&
-        featuresAtPixel.get("features").length === 1
-      ) {
-        // Case where a feature that wasn't clustered is expanded (there is just one element in the cluster)
-        handleFeatureToggle(featuresAtPixel.get("features")[0].get("idx"));
-      } else if (
-        featuresAtPixel &&
-        featuresAtPixel.get("features") &&
-        featuresAtPixel.get("features").length > 1
-      ) {
-        // Zoom in the clicked cluster it has more than `clusterExpandCountThreshold` features
-        // and is in a zoom level lower than `clusterExpandZoomThreshold`
-        if (
-          featuresAtPixel.get("features").length >
+        featuresAtPixel.attributes.type === 'single'
+            ) {
+                // Case when a feature is expanded
+            } else if (
+                featuresAtPixel &&
+        featuresAtPixel.get('features') &&
+        featuresAtPixel.get('features').length === 1
+            ) {
+                // Case where a feature that wasn't clustered is expanded (there is just one element in the cluster)
+                handleFeatureToggle(featuresAtPixel.get('features')[0].get('idx'));
+            } else if (
+                featuresAtPixel &&
+        featuresAtPixel.get('features') &&
+        featuresAtPixel.get('features').length > 1
+            ) {
+                // Zoom in the clicked cluster it has more than `clusterExpandCountThreshold` features
+                // and is in a zoom level lower than `clusterExpandZoomThreshold`
+                if (
+                    featuresAtPixel.get('features').length >
             mapConfig.clusterExpandCountThreshold &&
           mapRef.current.getView().getZoom() <
             mapConfig.clusterExpandZoomThreshold
-        ) {
-          mapRef.current
-            .getView()
-            .setCenter(
-              featuresAtPixel.get("features")[0].getGeometry().getCoordinates()
-            );
-          mapRef.current
-            .getView()
-            .animate({
-              zoom: mapRef.current.getView().getZoom() + 1,
-              duration: 500,
-            });
-        }
-      }
-    }
-  };
-
-  const selectedSensor = selectedFeature ? sensors[selectedFeature.idx] : null;
-
-  return (
-    <BaseMap
-      className={classes.content}
-      zoom={mapConfig.zoom}
-      center={mapConfig.center}
-      minZoom={mapConfig.minZoom}
-      maxZoom={mapConfig.maxZoom}
-      controls={[
-        cacheRef.current.fitViewControl,
-        cacheRef.current.clusterControl,
-        cacheRef.current.layersControl,
-        cacheRef.current.sourcesControl,
-      ]}
-      layers={Object.values(cacheRef.current.layers)}
-      updateMap={(map) => {
-        mapRef.current = map;
-        map.getOverlayById("popup").setElement(popupContainerRef.current);
-      }}
-      events={{
-        click: handleMapClick,
-        pointermove: (e) => {
-          // Show pointer when over a feature
-          if (!e.dragging) {
-            const pixel = e.map.getEventPixel(e.originalEvent);
-            const hit = e.map.hasFeatureAtPixel(pixel);
-            e.map.getTarget().style.cursor = hit ? "pointer" : "";
-          }
-        },
-      }}
-    >
-      <FitViewControl
-        el={cacheRef.current.fitViewControl.element}
-        center={mapConfig.center}
-        zoom={mapConfig.zoom}
-      />
-      {mapConfig.useCluster ? (
-        <ClusterControl
-          el={cacheRef.current.clusterControl.element}
-          cluster={clusterRef.current}
-          defaultDistance={mapConfig.clusterDistance}
-          toggleCallback={(isClustered) => {
-            const map = mapRef.current;
-            if (map) {
-              toggleCluster(isClustered);
-              map.getView().setZoom(map.getView().getZoom() + 0.001);
+                ) {
+                    mapRef.current
+                        .getView()
+                        .setCenter(
+                            featuresAtPixel.get('features')[0].getGeometry().getCoordinates()
+                        );
+                    mapRef.current
+                        .getView()
+                        .animate({
+                            zoom: mapRef.current.getView().getZoom() + 1,
+                            duration: 500
+                        });
+                }
             }
-          }}
-        />
-      ) : null}
-      {showExploreSources ? (
-        <SourcesControl
-        el={cacheRef.current.sourcesControl.element}
-          data={data}
-          sourcesConfig={sourcesConfig}
-          sources={sources}
-          selectedFeature={selectedFeature}
-          toggleRegions={toggleRegions}
-          handlePopupOpen={handlePopupOpen}
-          handlePopupClose={handlePopupClose}
-          className={classes.sourcesControl}
-          filterSources={filterSources}
-        />
-      ) : null}
-      {mapConfig.layers && showExploreLayers ? (
-        <LayersControl
-          el={cacheRef.current.layersControl.element}
-          layers={cacheRef.current.layers}
-          exclude={["basemaps"]}
-          layersInfo = { (typeof mapConfig.layersInfo === 'undefined') ? {} : mapConfig.layersInfo}
-        />
-      ) : null}
+        }
+    };
 
-      <div ref={popupContainerRef}>
-        {selectedSensor ? (
-          <SensorPopup
-            header={{
-              title: getSensorName(selectedSensor.properties),
-              color: getSourceColor(
-                sourcesConfig[selectedSensor.properties.type.id.toLowerCase()]
-              ),
+    const selectedSensor = selectedFeature ? sensors[selectedFeature.idx] : null;
+
+    return (
+        <BaseMap
+            className={classes.content}
+            zoom={mapConfig.zoom}
+            center={mapConfig.center}
+            minZoom={mapConfig.minZoom}
+            maxZoom={mapConfig.maxZoom}
+            controls={[
+                cacheRef.current.fitViewControl,
+                cacheRef.current.clusterControl,
+                cacheRef.current.layersControl,
+                cacheRef.current.sourcesControl
+            ]}
+            layers={Object.values(cacheRef.current.layers)}
+            updateMap={(map) => {
+                mapRef.current = map;
+                map.getOverlayById('popup').setElement(popupContainerRef.current);
             }}
-            sensor={sensors[selectedFeature.idx]}
-            parameters={parameters}
-            detailsLink={`/explore/detail/location/${encodeURIComponent(
-              selectedSensor.name
-            )}/All/`}
-            handleClose={() => handleFeatureToggle()}
-          />
-        ) : null}
-      </div>
-      {children}
-    </BaseMap>
-  );
+            events={{
+                click: handleMapClick,
+                pointermove: (e) => {
+                    // Show pointer when over a feature
+                    if (!e.dragging) {
+                        const pixel = e.map.getEventPixel(e.originalEvent);
+                        const hit = e.map.hasFeatureAtPixel(pixel);
+                        e.map.getTarget().style.cursor = hit ? 'pointer' : '';
+                    }
+                }
+            }}
+        >
+            <FitViewControl
+                el={cacheRef.current.fitViewControl.element}
+                center={mapConfig.center}
+                zoom={mapConfig.zoom}
+            />
+            {mapConfig.useCluster ? (
+                <ClusterControl
+                    el={cacheRef.current.clusterControl.element}
+                    cluster={clusterRef.current}
+                    defaultDistance={mapConfig.clusterDistance}
+                    toggleCallback={(isClustered) => {
+                        const map = mapRef.current;
+                        if (map) {
+                            toggleCluster(isClustered);
+                            map.getView().setZoom(map.getView().getZoom() + 0.001);
+                        }
+                    }}
+                />
+            ) : null}
+            {showExploreSources ? (
+                <SourcesControl
+                    el={cacheRef.current.sourcesControl.element}
+                    data={data}
+                    sourcesConfig={sourcesConfig}
+                    sources={sources}
+                    selectedFeature={selectedFeature}
+                    toggleRegions={toggleRegions}
+                    handlePopupOpen={handlePopupOpen}
+                    handlePopupClose={handlePopupClose}
+                    className={classes.sourcesControl}
+                    filterSources={filterSources}
+                />
+            ) : null}
+            {mapConfig.layers && showExploreLayers ? (
+                <LayersControl
+                    el={cacheRef.current.layersControl.element}
+                    layers={cacheRef.current.layers}
+                    exclude={['basemaps']}
+                    layersInfo = { (typeof mapConfig.layersInfo === 'undefined') ? {} : mapConfig.layersInfo}
+                />
+            ) : null}
+
+            <div ref={popupContainerRef}>
+                {selectedSensor ? (
+                    <SensorPopup
+                        header={{
+                            title: getSensorName(selectedSensor.properties),
+                            color: getSourceColor(
+                                sourcesConfig[selectedSensor.properties.type.id.toLowerCase()]
+                            )
+                        }}
+                        sensor={sensors[selectedFeature.idx]}
+                        parameters={parameters}
+                        detailsLink={`/explore/detail/location/${encodeURIComponent(
+                            selectedSensor.name
+                        )}/All/`}
+                        handleClose={() => handleFeatureToggle()}
+                    />
+                ) : null}
+            </div>
+            {children}
+        </BaseMap>
+    );
 };
 
 Map.defaultProps = {
-  showExploreLayers: true,
-  showExploreSources: true,
-  additionalLayer: undefined,
+    showExploreLayers: true,
+    showExploreSources: true,
+    additionalLayer: undefined
 };
 
 export default Map;


### PR DESCRIPTION
- [x]  Name change to Monitoring Locations from Explore Sources
- [x]  Use config to filter sources, created a variable called `filterSources` to be used in config so that the filtering option wont impact other projects in SourcesControl
- [x] Sources Filtering needs to be done in Map component
- [x] Make disable clustering the default option
          So this was done using, the same config parameter method, we render a different clustering control and in the initial render it ensures the cluster is off in the `ClusterControl`. To use it set the parameter `defaultDisableCluster` to true
          
![image](https://github.com/user-attachments/assets/6349019a-296f-4329-84b7-dd6564d3e479)

- [x] Fix font in Sources Control
    ![image](https://github.com/user-attachments/assets/9558692a-109d-460a-9232-cd58c644328d)

- [x] Add option in config for defaultVisibility of source, so all sources are not turned on

    ![image](https://github.com/user-attachments/assets/6bd9cef5-b91e-4286-a8fb-84d0dfb03f4b)

